### PR TITLE
Add AGENTS.md with Cursor Cloud development environment setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,40 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+DBTsearch is a React 18 + Express + PostgreSQL provider directory app. The legacy stack on `main` is the active development target. See `docs/GETTING-STARTED.md` for full setup docs and `docs/NOTES-FOR-AGENTS.md` for agent conventions.
+
+### Services
+
+| Service | Command | Port |
+|---------|---------|------|
+| Express API | `npx nodemon --watch server server/server.js` | 5001 |
+| Vite dev server | `npx vite --host 0.0.0.0` | 5173 |
+
+Vite proxies `/api` requests to the Express server on port 5001.
+
+### Database
+
+- PostgreSQL 16 is installed as a system package. Start it with `sudo pg_ctlcluster 16 main start`.
+- Database name: `dbtsearch`. Schema: `data/database.sql`. Import with `psql -d dbtsearch -f data/database.sql`.
+- The `.env` file must set `DATABASE_URL=postgresql://ubuntu:ubuntu@127.0.0.1:5432/dbtsearch` for the Express server to connect. Also set `SERVER_SESSION_SECRET` to a random string (min 8 chars).
+- The SQL file has a harmless duplicate `CREATE TABLE "users"` that errors but does not break the schema import.
+
+### Node version
+
+Use Node 20 (`source ~/.nvm/nvm.sh && nvm use 20`). pnpm v9 is the package manager (lockfile `pnpm-lock.yaml`), but npm scripts (`npm run server`, `npm run client`) work because pnpm is used only for install.
+
+### Testing
+
+- `npx vite build` — production build (outputs to `build/`).
+- `npx vitest run` — unit tests (no root-level test files exist currently; the only spec is in `frontend/` which is a separate sub-project).
+- No ESLint config exists at root level.
+- Smoke test: register a user, log in, view Admin, edit a provider, log out. See `docs/GETTING-STARTED.md` §4.
+
+### Gotchas
+
+- `pool.js` falls back to localhost:5432/dbtsearch without credentials if `DATABASE_URL` is unset. In Cloud Agent VMs, always set `DATABASE_URL` in `.env` with explicit credentials since the pg library requires a password for TCP connections.
+- The `data/database.sql` file contains a duplicate `CREATE TABLE "users"` statement that will error on import — this is harmless and the rest of the import completes.
+- The `.cursor/environment.json` runs `npm --prefix app install` which is for the Vue 3 sub-app in `app/` (stack-rewrite branch). This is unrelated to the legacy stack on `main`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud-specific development environment instructions for the legacy stack (React + Express + PostgreSQL on `main` branch).

## What's included

- Service overview (Express API on port 5001, Vite dev server on port 5173)
- PostgreSQL setup notes (database name, schema import, credentials)
- Node version requirements (Node 20, pnpm v9)
- Testing commands and current test coverage status
- Key gotchas discovered during setup (pool.js credential requirements, duplicate SQL statement)

## Demo

[dbtsearch_full_user_flow_demo.mp4](https://cursor.com/agents/bc-6bec9a87-4cc2-42f2-a8f8-3b2c7eaa1ef6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdbtsearch_full_user_flow_demo.mp4)

Full user flow: browse provider directory, login, admin page, logout.

[Provider directory homepage](https://cursor.com/agents/bc-6bec9a87-4cc2-42f2-a8f8-3b2c7eaa1ef6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage_providers.webp)
[Admin page after registration](https://cursor.com/agents/bc-6bec9a87-4cc2-42f2-a8f8-3b2c7eaa1ef6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fadmin_after_register.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6bec9a87-4cc2-42f2-a8f8-3b2c7eaa1ef6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6bec9a87-4cc2-42f2-a8f8-3b2c7eaa1ef6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

