### PR TITLE
Enable provider portal contact updates

### DIFF
--- a/modules/portal/services/ProviderPortalService.php
+++ b/modules/portal/services/ProviderPortalService.php
@@ -109,7 +109,7 @@ class ProviderPortalService extends Component
             'name' => (string)$provider->title,
             'phone' => (string)($provider->getFieldValue('phone') ?? ''),
             'email' => (string)($provider->getFieldValue('email') ?? ''),
-            'website' => (string)($provider->getFieldValue('website') ?? ''),
+            'website' => $this->getWebsiteUrl($provider),
             'dateUpdated' => $provider->dateUpdated
                 ? DateTimeHelper::toDateTime($provider->dateUpdated)->format('c')
                 : null,
@@ -141,14 +141,17 @@ class ProviderPortalService extends Component
         $provider->title = $name;
         $fieldValues = [];
 
-        if (array_key_exists('phone', $data)) {
+        if (array_key_exists('phone', $data) && $data['phone'] !== null) {
             $fieldValues['phone'] = trim((string)$data['phone']);
         }
-        if (array_key_exists('email', $data)) {
+        if (array_key_exists('email', $data) && $data['email'] !== null) {
             $fieldValues['email'] = trim((string)$data['email']);
         }
-        if (array_key_exists('website', $data)) {
-            $fieldValues['website'] = trim((string)$data['website']);
+        if (array_key_exists('website', $data) && $data['website'] !== null) {
+            $website = $this->normalizeWebsiteUrl(trim((string)$data['website']));
+            $fieldValues['website'] = $website === ''
+                ? null
+                : ['value' => $website, 'type' => 'url'];
         }
 
         if ($fieldValues !== []) {
@@ -260,6 +263,35 @@ class ProviderPortalService extends Component
         }
 
         return $errors;
+    }
+
+    private function getWebsiteUrl(Entry $provider): string
+    {
+        try {
+            $website = $provider->getFieldValue('website');
+        } catch (\Throwable) {
+            return '';
+        }
+
+        if (is_object($website) && method_exists($website, 'getUrl')) {
+            return trim((string)$website->getUrl());
+        }
+
+        return trim((string)($website ?? ''));
+    }
+
+    private function normalizeWebsiteUrl(string $url): string
+    {
+        $url = trim($url);
+        if ($url === '') {
+            return '';
+        }
+
+        if (!preg_match('#^https?://#i', $url)) {
+            $url = 'https://' . ltrim($url, '/');
+        }
+
+        return $url;
     }
 
     public function stampAvailabilityUpdatedAtIfChanged(Entry $location, ?bool $previousAvailability = null): void

--- a/templates/manage/index.twig
+++ b/templates/manage/index.twig
@@ -8,7 +8,7 @@
 {% set activeNav = 'manage' %}
 
 {% set portalFeatures = {
-  practiceDetails: false,
+  practiceDetails: true,
   dbtaCertified: true,
   locationDetails: false,
   craftSave: true,
@@ -58,12 +58,24 @@
   {% endfor %}
 {% endif %}
 
+{% set portalWebsiteField = providerEntry ? (attribute(providerEntry, 'website') ?? attribute(providerEntry, 'urlField') ?? null) : null %}
+{% set portalWebsiteUrl = '' %}
+{% if portalWebsiteField %}
+  {% if portalWebsiteField.url is defined and portalWebsiteField.url %}
+    {% set portalWebsiteUrl = portalWebsiteField.url %}
+  {% elseif portalWebsiteField.value is defined and portalWebsiteField.value %}
+    {% set portalWebsiteUrl = portalWebsiteField.value %}
+  {% else %}
+    {% set portalWebsiteUrl = portalWebsiteField %}
+  {% endif %}
+{% endif %}
+
 {% set portalProvider = providerEntry ? {
   id: providerEntry.id,
   name: providerEntry.title,
   phone: providerEntry.phone ?? '',
   email: providerEntry.email ?? '',
-  website: providerEntry.website ?? '',
+  website: portalWebsiteUrl,
   dateUpdated: providerEntry.dateUpdated ? providerEntry.dateUpdated|date('c') : null,
   locations: portalLocations,
 } : {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Providers can now update listing **phone**, **email**, and **website** from `/manage`.

The UI and save path already existed behind `practiceDetails: false`. This change turns that flag on and fixes Craft Link field handling so website values load and persist correctly.

## Changes

- Enable `practiceDetails` in [`templates/manage/index.twig`](templates/manage/index.twig)
- Resolve Link → URL when prefilling the website input (Twig + `buildPortalData`)
- Save website as `['value' => $url, 'type' => 'url']`, normalize missing `https://`, and skip null contact params so absent POST keys cannot wipe contacts

## Test plan

- [ ] Log into `/manage` as a provider user
- [ ] Open **Edit details** and confirm phone, email, and website are prefilled
- [ ] Update all three fields, save, reload — values persist
- [ ] Clear website and save — listing website clears in directory
- [ ] Toggle only availability (details panel closed) and save — contacts remain unchanged
- [ ] Confirm updated contacts appear on the public directory listing
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9624-405e-749f-83aa-555da34fc4ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9624-405e-749f-83aa-555da34fc4ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

